### PR TITLE
Skip model configs having unknown platform

### DIFF
--- a/examples/rknn_convert/rknn_convert.py
+++ b/examples/rknn_convert/rknn_convert.py
@@ -60,7 +60,8 @@ def convert_model(model_path, out_path, pre_compile):
             model_file_path = os.path.join(model_path, model['model_file_path'])
             rknn.load_onnx(model=model_file_path)
         else:
-            print("platform %s not support!" % (model['platform']))
+            print("Platform {:} is not supported! Moving on.".format(model['platform']))
+            continue
         print('done')
 
         if model['quantize']:


### PR DESCRIPTION
If a model with an unsupported platform is encountered, an error test is displayed but the conversion is still attempted with no module loaded. Didn't actually try (it should fail), but it looks incorrect.